### PR TITLE
Add `big-js` as dependency requirement

### DIFF
--- a/milestones/MILESTONE_1.md
+++ b/milestones/MILESTONE_1.md
@@ -7,9 +7,11 @@ Every project has its beginning in setting up some basic structure and tooling. 
 
 1. Use `create-react-app` to initialize a new React app
     - Documentation: [https://github.com/facebook/create-react-app](https://github.com/facebook/create-react-app)
-2. Delete any unnecessary file or asset
-3. Run the application with `npm start` and make sure that everything works correctly.
-4. Follow the instructions in `create-react-app-buildpack` to deploy the app to Heroku
+2. Delete any unnecessary file or asset3. 
+3. Add the necessary packages to your project:
+    - Add [`big-js`](https://www.npmjs.com/package/big-js) using npm
+4. Run the application with `npm start` and make sure that everything works correctly.
+5. Follow the instructions in `create-react-app-buildpack` to deploy the app to Heroku
     - Initialize a git repo
     - Create a Heroku app
     - Commit and deploy to Heroku


### PR DESCRIPTION
## Description of issue

[As discussed](https://gitlab.com/microverse/guides/tse/code_review/code_review_guidelines/issues/37), students mostly use a different package for the `operate` function as requested by the [project requirements in milestone 4](https://microverse.pathwright.com/library/fast-track-curriculum/69047/path/step/44896094/). Instead of using the `big-js` students mostly use `big.js` which result in linter errors sometimes. See https://github.com/frederico-miranda/react-calculator/pull/6/commits/4359abbc6f6832141b418517cbf9206c5f37e73f for example as shown in the screenshot
   ![image](https://user-images.githubusercontent.com/36057474/73358430-dc821500-429e-11ea-9cb3-949ec0db0406.png)


## Proposed Solution

This PR address this issue by adding the requirement.